### PR TITLE
Use: prefix `.grid-` class on quiz page

### DIFF
--- a/src/pages/QuestionPage/QuizPage/index.tsx
+++ b/src/pages/QuestionPage/QuizPage/index.tsx
@@ -25,7 +25,7 @@ export const QuizPage: React.VFC<Props> = ({ quizId, quizData, cheat }) => {
 
   const { gridStyleDisp, gridStyleObj } = useMemo(
     () => ({
-      gridStyleDisp: `.container {
+      gridStyleDisp: `.grid-container {
   display: grid;
 ${indent(gridStyle)}
 }`,
@@ -47,7 +47,7 @@ ${indent(subgridStyle)}
   }, [subgridStyle]);
   const { itemStyleDisp, itemStyleObj } = useMemo(
     () => ({
-      itemStyleDisp: `.item {
+      itemStyleDisp: `.grid-item {
 ${indent(itemStyle)}
 }`,
       itemStyleObj: simpleParseCss(itemStyle),


### PR DESCRIPTION
I changed the class name (`.grid-container`, `.grid-item`) in the sample code on the tutorial to be the same as the class name in the actual quiz page.

<img width="1054" alt="Screen Shot: Use the same class name on sample code" src="https://user-images.githubusercontent.com/1996642/150668056-97d0521a-b5d3-4b02-bc7f-0d84d29f4a08.png">
